### PR TITLE
Ignore clear in history

### DIFF
--- a/sensible.bash
+++ b/sensible.bash
@@ -44,7 +44,7 @@ HISTFILESIZE=100000
 HISTCONTROL="erasedups:ignoreboth"
 
 # Don't record some commands
-export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history"
+export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history:clear"
 
 # Useful timestamp format
 HISTTIMEFORMAT='%F %T '


### PR DESCRIPTION
I happen to use control-L, but if people type `clear` it probably doesn't need to be included in the history.
