### PR TITLE
Quiet error when trying to set dirspell on old bash

### DIFF
--- a/sensible.bash
+++ b/sensible.bash
@@ -62,7 +62,7 @@ bind '"\e[D": backward-char'
 # Prepend cd to directory names automatically
 shopt -s autocd 2> /dev/null
 # Correct spelling errors during tab-completion
-shopt -s dirspell 
+shopt -s dirspell 2> /dev/null
 # Correct spelling errors in arguments supplied to cd
 shopt -s cdspell 2> /dev/null
 


### PR DESCRIPTION
OS X version of bash doesn't support dirspell, so suppressing the error when setting like was already done for cdspell.
