### PR TITLE
Comment out CDPATH by default

### DIFF
--- a/sensible.bash
+++ b/sensible.bash
@@ -92,7 +92,7 @@ shopt -s cdspell 2> /dev/null
 # This defines where cd looks for targets
 # Add the directories you want to have fast access to, separated by colon
 # Ex: CDPATH=".:~:~/projects" will look for targets in the current working directory, in home and in the ~/projects folder
-CDPATH="."
+# CDPATH="."
 
 # This allows you to bookmark your favorite places across the file system
 # Define a variable containing a path and you will be able to cd into it regardless of the directory you're in


### PR DESCRIPTION
CDPATH="." has no effect besides making cd print out the directory being changed to.

With only one entry in CDPATH, this serves no purpose and is completely extraneous.