### PR TITLE
Fix .bash_history truncation on some sessions

### DIFF
--- a/sensible.bash
+++ b/sensible.bash
@@ -62,6 +62,9 @@ PROMPT_COMMAND='history -a'
 HISTSIZE=500000
 HISTFILESIZE=100000
 
+# Change the file location because some bash sessions truncate .bash_history
+export HISTFILE=~/.history_bash
+    
 # Avoid duplicate entries
 HISTCONTROL="erasedups:ignoreboth"
 


### PR DESCRIPTION
http://superuser.com/questions/575479/bash-history-truncated-to-500-lines-on-each-login