### PR TITLE
If not interactive, do nothing

### DIFF
--- a/sensible.bash
+++ b/sensible.bash
@@ -3,6 +3,11 @@
 # Repository: https://github.com/mrzool/bash-sensible
 # Version: 0.2.2
 
+# If shell is not interactive: do nothing
+if [[ $- != *i* ]] ; then
+  return
+fi
+
 # Unique Bash version check
 if ((BASH_VERSINFO[0] < 4))
 then 


### PR DESCRIPTION
When the shell is not an interactive shell, return from the bashrc directly. Avoid sourcing unnecessary config for a shell you'll never see.

This line should be at the top of .bashrc, so if someone source this file from his own .bashrc he/she is better of moving this line to his file.

But it is nonetheless effective here, and as one of this project use-case is to be a model for people own config or to be systematically install on shared machine account as .bashrc, I think it is a good things to add.

Best Regards,
Aeredren 